### PR TITLE
[V2PROD-200] Only execute frontend CI on frontend branches

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,13 +37,13 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
 
-      - name: 'hardhat compile'
-        env:
-          DEFAULT_NETWORK: ${{ secrets.DEFAULT_NETWORK }}
-        run: |
-          yarn contracts build
+      # - name: 'hardhat compile'
+      #   env:
+      #     DEFAULT_NETWORK: ${{ secrets.DEFAULT_NETWORK }}
+      #   run: |
+      #     yarn contracts build
 
-      - name: Run Unit Test
+      - name: 'hardhat test'
         env:
             DEFAULT_NETWORK: ${{ secrets.DEFAULT_NETWORK }}
             MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,7 +56,7 @@ jobs:
             ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
             CMC_KEY: ${{ secrets.CMC_KEY }}
             DISABLE_LOGS: ${{ secrets.DISABLE_LOGS }}
-        run: yarn hardhat test
+        run: yarn contracts test
 
       - name: 'build production'
         if: startsWith(${{github.ref}}, 'refs/heads/app/')

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,7 @@ jobs:
           yarn contracts build
 
       - name: 'build production'
-        if: "$CI_BRANCH == app/**"
+        if: "$CI_COMMIT_BRANCH == app/**"
         run: |
           yarn start optimize --force 
           yarn build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,11 +37,11 @@ jobs:
             ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --immutable
 
-      # - name: 'hardhat compile'
-      #   env:
-      #     DEFAULT_NETWORK: ${{ secrets.DEFAULT_NETWORK }}
-      #   run: |
-      #     yarn contracts build
+      - name: 'hardhat compile'
+        env:
+          DEFAULT_NETWORK: ${{ secrets.DEFAULT_NETWORK }}
+        run: |
+          yarn contracts build
 
       - name: 'hardhat test'
         env:
@@ -56,7 +56,7 @@ jobs:
             ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
             CMC_KEY: ${{ secrets.CMC_KEY }}
             DISABLE_LOGS: ${{ secrets.DISABLE_LOGS }}
-      - run: yarn hardhat test
+        run: yarn hardhat test
 
       - name: 'build production'
         if: startsWith(${{github.ref}}, 'refs/heads/app/')

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,6 +44,7 @@ jobs:
           yarn contracts build
 
       - name: 'build production'
+        if: "$CI_BRANCH == app/**"
         run: |
           yarn start optimize --force 
           yarn build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,6 +44,7 @@ jobs:
           yarn contracts build
 
       - name: 'build production'
+        if: startsWith(${{github.ref}}, 'refs/heads/app/')
         run: |
           yarn start optimize --force 
           yarn build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,6 +44,18 @@ jobs:
           yarn contracts build
 
       - name: Run Unit Test
+        env:
+            DEFAULT_NETWORK: ${{ secrets.DEFAULT_NETWORK }}
+            MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+            KOVAN_RPC_URL: ${{ secrets.KOVAN_RPC_URL }}
+            GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL }}
+            RINKEBY_RPC_URL: ${{ secrets.RINKEBY_RPC_URL }}
+            ROPSTEN_RPC_URL: ${{ secrets.ROPSTEN_RPC_URL }}
+            POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL }}
+            MUMBAI_RPC_URL: ${{ secrets.MUMBAI_RPC_URL }}
+            ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
+            CMC_KEY: ${{ secrets.CMC_KEY }}
+            DISABLE_LOGS: ${{ secrets.DISABLE_LOGS }}
       - run: yarn hardhat test
 
       - name: 'build production'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,7 @@ jobs:
           yarn contracts build
 
       - name: 'build production'
-        if: "$CI_COMMIT_BRANCH == app/**"
+        if: ${{ github.ref == 'app/**' }}
         run: |
           yarn start optimize --force 
           yarn build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,6 +43,9 @@ jobs:
         run: |
           yarn contracts build
 
+      - name: Run Unit Test
+      - run: yarn hardhat test
+
       - name: 'build production'
         if: startsWith(${{github.ref}}, 'refs/heads/app/')
         run: |


### PR DESCRIPTION
It is:
- Disable frontend CI to only run when branch name matches format "app/**"